### PR TITLE
Adding OpenMP support for Mac

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ocefpaf
+* @ocefpaf @smmaurer

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About pandana
 =============
 
-Home: https://udst.github.io/pandana
+Home: https://github.com/udst/pandana
 
 Package license: AGPL-3.0
 
@@ -9,6 +9,7 @@ Feedstock license: BSD 3-Clause
 
 Summary: Pandas Network Analysis - dataframes of network queries, quickly
 
+Pandana performs hundreds of thousands of network queries in under a second (for walking-scale distances) using a Pandas-like API. The computations are parallelized for multi-core machines using an underlying C++ library.
 
 
 Current build status
@@ -186,4 +187,5 @@ Feedstock Maintainers
 =====================
 
 * [@ocefpaf](https://github.com/ocefpaf/)
+* [@smmaurer](https://github.com/smmaurer/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,9 @@ source:
   sha256: 4069fc9dd220f0e189de4ac56d8e65cf97e4619544ce249466bd7f3abd7b41fe
   patches:
     - functional.patch
-    - no_fopenmp.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -20,13 +19,16 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - llvm-openmp  # [osx]
   host:
     - python
     - pip
     - cython >=0.25.2
+    - llvm-openmp  # [osx]
     - numpy
   run:
     - {{ pin_compatible('numpy') }}
+    - llvm-openmp  # [osx]
     - matplotlib >=1.3.1
     - numpy >=1.8.0
     - osmnet >=0.1.2
@@ -39,17 +41,23 @@ requirements:
 test:
   imports:
     - pandana
+    - pandana.cyaccess
     - pandana.loaders
   requires:
     - pytest
 
 about:
-  home: https://udst.github.io/pandana
+  home: https://github.com/udst/pandana
   license: AGPL-3.0
   license_family: AGPL
-  license_file: LICENSE
+  license_file: LICENSE.txt
   summary: "Pandas Network Analysis - dataframes of network queries, quickly"
+  description: |
+    Pandana performs hundreds of thousands of network queries in under a second (for walking-scale distances) using a Pandas-like API. The computations are parallelized for multi-core machines using an underlying C++ library.
+  doc_url: https://udst.github.io/pandana
+  dev_url: https://github.com/udst/pandana
 
 extra:
   recipe-maintainers:
+    - smmaurer
     - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,9 @@ source:
 build:
   number: 1
   skip: True  # [win and vc<14]
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script:
+    - export LDFLAGS="$LDFLAGS -fopenmp"  # [osx]
+    - "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   build:


### PR DESCRIPTION
Hi @ocefpaf! 

This PR is an attempt to enable OpenMP support for Macs by following the instructions here: https://conda-forge.org/docs/maintainer/knowledge_base.html#openmp-on-macos. 

We've been doing something similar for local compilation, having Mac users install `llvm-openmp` and `clang` from Conda Forge, and it works great.

Separately: I don't understand these things well enough to know why the Windows Python 2.7 build wasn't working in PR #1, but do you think it's something we can fix? It would be nice to support that combination still.

Thanks so much for everything you've done to set up this recipe and to troubleshoot it.

@conda-forge-admin, please rerender

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->